### PR TITLE
Rename "Pending Completed" to "Completed Compactions"

### DIFF
--- a/grafana/dashboards/dse-cluster-metrics.json
+++ b/grafana/dashboards/dse-cluster-metrics.json
@@ -3947,7 +3947,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Pending Completed / node / $rate",
+          "title": "Completed Compactions / node / $rate",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
Original name from dashboard isn't understandable, so it's better to rename it to real name