### PR TITLE
Better name for NodeSync metrics

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -203,9 +203,9 @@ scrape_configs:
        replacement: dse_hints_${1}
      #NodeSync Metrics
      - source_labels: ["dse"]
-       regex: com\.datastax\.nodesync\.node_sync_metrics\.(\w+)
+       regex: com\.datastax\.nodesync\.node_sync_metrics\.(node_sync_)?(\w+)
        target_label: __name__
-       replacement: dse_node_sync_${1}
+       replacement: dse_node_sync_${2}
      #ContinuousPaging Metrics
      - source_labels: ["dse"]
        regex: org\.apache\.cassandra\.metrics\.continuous_paging\.(\w+)


### PR DESCRIPTION
Right now, NodeSync metrics have names like this
`dse_node_sync_node_sync_data_repaired_total` with two `node_sync` words in it.  Given
patch leaves only one there: `dse_node_sync_data_repaired_total`.

Another possible fix for this one could be to leave regex as-is, and change replacement to
`dse_${1}` but this may not work in the future when metrics may not have `node_sync_` prefix.